### PR TITLE
Refactor date query interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Fbtrack is a command-line utility supporting participant management and data col
 
 ## Requirements
 
-- You have an internet-connected Mac or Linux, with Google Chrome and Node.js 12+ installed. 
+- This application is built for Mac only, with Google Chrome and Node.js 12+ installed. 
 - You are registering subjects in person via the computer hosting fbtrack
 - You or the study administrator are willing to use the terminal on a very basic level.
 - You are creating [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html)-compliant participant ids that in no way identify your subjects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "body-parser": "^1.19.0",
         "colors": "^1.4.0",
-        "commander": "^4.0.1",
+        "commander": "^9.4.0",
         "cors": "^2.8.5",
         "date-fns": "^2.8.1",
         "dotenv": "^8.2.0",
@@ -218,11 +218,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
-        "node": ">= 6"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-map": {
@@ -2462,9 +2462,9 @@
       }
     },
     "commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "colors": "^1.4.0",
-    "commander": "^4.0.1",
+    "commander": "^9.4.0",
     "cors": "^2.8.5",
     "date-fns": "^2.8.1",
     "dotenv": "^8.2.0",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -40,8 +40,8 @@ cli
   .option('-p, --participant-ids <participantIds>', 'a comma-delimited list of participants', splitArgsOn(','))
   .option('-w, --window-size <windowSize>', 'window size', Number)
   .option('-r, --refresh', 'refresh oauth token')
-  .option('-d, --date-range <start>..<stop>','specify a date or date range in the format of yyyy-mm-dd', splitArgsOn('..'))
-  .option('-n, --chunk-size <chunkSize>','Number of participants to query simultaneously', Number)
+  .option('-d, --date-range <dates...>', 'specify a date or date range in the format of yyyy-mm-dd')
+  .option('-n, --chunk-size <chunkSize>', 'Number of participants to query simultaneously', Number)
   .action(query)
 
   /*

--- a/src/cli/register.js
+++ b/src/cli/register.js
@@ -1,6 +1,6 @@
-const { APP_CONFIG } = require('../config').getConfig();
+const config = require('../config').getConfig();
 const { exec } = require('child_process')
-const server = require(APP_CONFIG.SERVER_PATH)
+const server = require(config.app.SERVER_PATH)
 
 function main() {
   server.start(() => {})
@@ -9,8 +9,8 @@ function main() {
 function openAppInChrome(port) {
 
     exec(
-        `open -a '/Applications/Google Chrome.app' ${`http://localhost:${APP_CONFIG.SERVER_PORT}/start`}`, 
-        { 'cwd': APP_CONFIG.SERVER_PATH }, 
+        `open -a '/Applications/Google Chrome.app' ${`http://localhost:${config.app.SERVER_PORT}/start`}`, 
+        { 'cwd': config.app.SERVER_PATH }, 
         function(err) { 
             if (err) throw err; 
         }  

--- a/src/cli/report.js
+++ b/src/cli/report.js
@@ -1,13 +1,7 @@
 const { format, parseISO, subDays } = require('date-fns')
 const { groupBy } = require('lodash')
 
-const { FITBIT_CONFIG, APP_CONFIG } = require('../config').getConfig()
-const {
-  DB_NAME,
-  DB_PATH,
-  DB_FILENAME,
-  RAW_DATA_PATH
-} = APP_CONFIG
+const config = require('../config').getConfig()
 
 const {
   dates,
@@ -37,12 +31,12 @@ const {
 const makeList = listFormatter('•')
 
 const { Database, Study } = require('../models');
-const db = new Database({ databaseName: DB_NAME });
-const metrics = Object.keys(FITBIT_CONFIG.ENDPOINTS)
+const db = new Database({ databaseName: config.app.DB_NAME });
+const metrics = Object.keys(config.fitbit.ENDPOINTS)
 
 async function main({ all = false, participantIds:targetIds = [], missingOnly = false }) {
 
-  const allParticipantFiles = await getFiles({ directory: RAW_DATA_PATH })
+  const allParticipantFiles = await getFiles({ directory: config.app.RAW_DATA_PATH })
   const participants = await db.getParticipants({ active: true })
 
   const validParticipants = []

--- a/src/cli/test.query.js
+++ b/src/cli/test.query.js
@@ -9,7 +9,7 @@ const {
   subDays
 } = require('date-fns')
 
-const { FITBIT_CONFIG } = require('../config').getConfig();
+const { FITBIT } = require('../config').getConfig();
 const { generateQueryPathsByDate } = require('./query')
 
 const { dates, io } = require('../lib')

--- a/src/cli/validators.js
+++ b/src/cli/validators.js
@@ -1,7 +1,4 @@
-const { USER_CONFIG, APP_CONFIG } = require('../config').getConfig();
-const windowSize = USER_CONFIG.WINDOW_SIZE;
-
-
+const config = require('../config').getConfig();
 const dates = require('../lib/dates')
 const { defaultLogger: logger } = require('../lib/logger')
 
@@ -23,7 +20,7 @@ const validators = {
   configure: id,
   query: async function(...args) {
 
-    const [{ all, chunkSize=APP_CONFIG.CHUNK_SIZE, participantIds, dateRange, windowSize, refresh }] = args
+    const [{ all, chunkSize=config.app.CHUNK_SIZE, participantIds, dateRange, windowSize=null, refresh }] = args
 
     if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
       logger.error('-n, --chunk-size requires a non-negative integer argument.')
@@ -48,9 +45,15 @@ const validators = {
     if (dateRange && dateRange.length > 0) {
 
       if (dateRange.length > 2) {
-        logger.error('Invalid Date range.  please provide a max of two dates, separated by "..."')
+        logger.error(`Invalid --date arguments.  ${dateRange.length} arguments were provided, please provide a max of two dates.`)
         process.exit(1)
       }
+
+      if (dateRange.length === 2 && new Date(dateRange[0]) > new Date(dateRange[1])) {
+        logger.error('Invalid --date arguments.  2 dates supplied, but first (start date) occurs after second (stop date).')
+        process.exit(1)
+      }
+
 
       if (windowSize != null) {
         logger.error('Provide a window size or a date range, but not both.')
@@ -65,7 +68,7 @@ const validators = {
 
     } else if (windowSize == null) {
 
-      logger.info(`No date range or window flag passed. Using default window size of ${ WINDOW_SIZE } days`)
+      logger.info(`No date range or window flag passed. Using default window size of ${ config.user.WINDOW_SIZE } days`)
 
     } else if (isNaN(windowSize) || windowSize <= 0) {
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,5 @@
-const path = require('path')
-
-const parsedFromConfig = require('dotenv').config({
-  path: path.join(__dirname, '..', 'USER_CONFIG.env')
-}).parsed
+const path = require('path');
+const dotenv = require('dotenv');
 
 const defaultUserConfig = {
   CALLBACK_URL: 'http://localhost:3000/store_subject_data',
@@ -11,7 +8,7 @@ const defaultUserConfig = {
   SCOPE: null,
   STUDY_NAME: null,
   WINDOW_SIZE: 3,
-}
+};
 
 const ENDPOINTS = new Map([
   [ "sleep",                "/sleep/date/%DATE%.json" ],
@@ -24,6 +21,11 @@ const ENDPOINTS = new Map([
 
 function getConfig (requiresUserSetup = false) {
 
+    const parsedFromConfig = dotenv.config({
+      path: path.join(__dirname, '..', 'USER_CONFIG.env')
+    }).parsed;
+
+
   if (requiresUserSetup && !parsedFromConfig) {
     console.log(`\nERROR: Could not find configuration file ${path.join(__dirname, '..', 'USER_CONFIG.env')}.
 If you haven't yet configured fbtrack, please run 'fbtrack configure'.\n`)
@@ -32,7 +34,7 @@ If you haven't yet configured fbtrack, please run 'fbtrack configure'.\n`)
 
   return { 
 
-    USER_CONFIG: {
+    user: {
       CALLBACK_URL,
       CLIENT_ID,
       CLIENT_SECRET,
@@ -41,7 +43,7 @@ If you haven't yet configured fbtrack, please run 'fbtrack configure'.\n`)
       WINDOW_SIZE,
     } = (parsedFromConfig || defaultUserConfig),
 
-    APP_CONFIG: {
+    app: {
       DB_NAME: (parsedFromConfig || defaultUserConfig).STUDY_NAME,
       DB_PATH: path.join(__dirname, 'db'),
       SERVER_PATH: path.join(__dirname, 'web'),
@@ -51,7 +53,7 @@ If you haven't yet configured fbtrack, please run 'fbtrack configure'.\n`)
       CHUNK_SIZE: 3,
     },
 
-    FITBIT_CONFIG: {
+    fitbit: {
       AUTH_URI: 'https://www.fitbit.com/oauth2/authorize',
       ACCESS_TOKEN_URI: 'https://api.fitbit.com/oauth2/token',
       CALLBACK_URL,
@@ -62,7 +64,7 @@ If you haven't yet configured fbtrack, please run 'fbtrack configure'.\n`)
       SCOPE,
     },
 
-    SERVER_CONFIG: {
+    server: {
       PORT: 3000
     }
 

--- a/src/lib/dates.js
+++ b/src/lib/dates.js
@@ -1,3 +1,4 @@
+const config = require('../config').getConfig({ requiresUserSetup: true })
 const {
   addDays,
   differenceInDays,
@@ -11,16 +12,61 @@ const {
 
 
 // e.g. 201_2020-01-10_activities-calories.json
+// TODO: validate subject ids to disallow '_'
 const filenamePattern = /^.+_[2][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[^.]*\.json$/
 const ymdFormat = 'yyyy-MM-dd' // this is fitbit's resource url format
 const dateRE = /[2][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/
 const dateREStrict = /^[2][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/
 
+
+function formatDateYYYYMMDD(date) {
+
+  const year = date.getUTCFullYear()
+  const month  = date.getUTCMonth() + 1;
+  const day = date.getUTCDate();
+  const formattedDate = `${year}-${month < 10 ? '0' + month : month}-${day < 10 ? '0' + day : day}`;
+
+  return formattedDate;
+}
+
+function calculateStartAndStopDates(dateRange=[], windowSize=null) {
+
+    // TODO: turn this into a fn
+  let dateStart, dateStop;
+
+  if (dateRange.length === 0) {
+
+    if (windowSize == null) {
+        windowSize = Number(config.user.WINDOW_SIZE)
+    }
+
+    dateStop = new Date();
+    dateStart = subDays(new Date(dateStop), windowSize);
+
+  } else if (dateRange.length === 1) {
+
+    dateStop = new Date(dateRange[0]);
+    dateStart = subDays(dateStop, 3)
+
+  } else if (dateRange.length === 2) {
+
+    dateStop = new Date(dateRange[1]);
+    dateStart = new Date(dateRange[0]);
+
+  }
+
+  return [ dateStart, dateStop ]
+
+}
+
 function datesWithinBoundaries(start, stop) {
 
   /*
+   * TODO: better fn docs needed generally!
+   *
    * - range is inclusive
    * - returns dates
+   *
    */
 
   if (differenceInDays(stop, start) < 0) {
@@ -30,6 +76,7 @@ function datesWithinBoundaries(start, stop) {
   const dates = []
   let currentDate = start
 
+    // FIXME:off by one
   while (currentDate <= stop) {
     dates.push(currentDate)
     currentDate = addDays(currentDate, 1)
@@ -60,42 +107,13 @@ function dateBoundariesFromWindowSize({ windowSize, registrationDate, today=new 
 
 }
 
-function dateBoundariesFromDates({ dates, registrationDate, participantId }) {
-
-  if (!dates || dates.length < 1 || dates.length > 2) {
-    throw new Error('Dates array requires exactly two elements. Received ', JSON.stringify(dates))
-  }
-
-  if (dates.length === 2 && dates[0] > dates[1]) {
-    throw new Error('Stop Date before Start Date')
-  }
-
-  const [ potentialStart, stop ] = dates
-
-  if (isBefore(stop, registrationDate)) {
-    console.warn('end date before registration date. using registration date as start date in range.')
-    // probably need to warn about participant id here, but requires larger changes.
-    return []
-  }
-
-  if (isBefore(potentialStart, registrationDate)) {
-    console.warn('start date before registration date. using registration date as start date in range.')
-  }
-
-  const startUnixEpoch = max([potentialStart, registrationDate])
-  console.log(potentialStart, registrationDate, startUnixEpoch)
-  const start = parseISO(startUnixEpoch.toISOString())
-
-  return start && stop ? [ start, stop ] : [ start || stop, start || stop ]
-
-}
-
 module.exports = exports = {
   datesWithinBoundaries,
   dateBoundariesFromWindowSize,
-  dateBoundariesFromDates,
+  calculateStartAndStopDates,
   dateRE,
   dateREStrict,
   filenamePattern,
+  formatDateYYYYMMDD,
   ymdFormat,
 }

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,4 +1,4 @@
-const { APP_CONFIG } = require('../config').getConfig();
+const config = require('../config').getConfig();
 const fs = require('fs');
 const format = require('date-fns/format');
 const { inspect, promisify } = require('util');
@@ -89,7 +89,7 @@ class Logger {
 }
 
 const defaultLogger = new Logger({
-  logDir: APP_CONFIG.LOGS_PATH,
+  logDir: config.app.LOGS_PATH,
   label: true,
   config: {
     info: false,

--- a/src/lib/participantFile.js
+++ b/src/lib/participantFile.js
@@ -1,8 +1,0 @@
-const dateRE = /[2][0][1-9][0-9]-[0-9][0-9]-[0-9][0-9]/
-const validFilename = fname => {
-  const [ id, metric, captureDate, extension] =  fname.split(/[\._]/)
-  // verify
-}
-module.exports = {
-
-}

--- a/src/models/Database.js
+++ b/src/models/Database.js
@@ -1,15 +1,15 @@
 const sqlite = require('sqlite')
 const path = require('path')
 const { MissingParameterError, requireParam } = require('../lib/utils');
-const { APP_CONFIG } = require('../config').getConfig({ requiresUserSetup: true })
+const config = require('../config').getConfig({ requiresUserSetup: true })
 
-const { participants } = require(path.join(APP_CONFIG.DB_PATH, 'statements'))
+const { participants } = require(path.join(config.app.DB_PATH, 'statements'))
 
 class Database {
 
   constructor({ databaseName }) {
 
-    this.databaseName = path.join(APP_CONFIG.DB_PATH, databaseName)
+    this.databaseName = path.join(config.app.DB_PATH, databaseName)
     this.dbPromise = sqlite.open(`${ this.databaseName }.sqlite`, { Promise, cached: true })
 
   }

--- a/src/models/test.Study.js
+++ b/src/models/test.Study.js
@@ -5,6 +5,7 @@ const path = require('path')
 const tape = require('tape')
 const { default: tapePromise } = require('tape-promise')
 
+const config = require('../config').getConfig()
 const Study = require('./Study')
 const TEST_DATA_DIR = path.join(__dirname, 'test-data')
 const TEST_PARTICIPANT_IDS = ['test1','test2']
@@ -25,13 +26,9 @@ const TEST_FILE_PARTS = [
   '.json',
 ]
 
-const { APP_CONFIG } = require('../config').getConfig()
-const { DB_PATH, DB_NAME } = APP_CONFIG
 const Database = require('./Database')
 const database = new Database({ databaseName: 'test-databases/test-database-study' })
-
 const test = tapePromise(tape)
-
 const rmDir = (path) => execSync(`rm -rf ${path}`, { encoding: 'utf8' })
 
 const seedTestDataFlat = (dirPath) => {

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -1,24 +1,21 @@
 const { exec } = require('child_process')
 const path = require('path')
 const express = require('express')
-const expressHandlebars = require('express-handlebars')
+const { engine } = require('express-handlebars')
 const bodyParser = require('body-parser')
 const cors = require('cors')
 
-const {
-  APP_CONFIG,
-  USER_CONFIG
-} = require('../config').getConfig()
+const config = require('../config').getConfig()
 
 const routes = require('./routes')
 const { defaultLogger:logger } = require('../lib/logger')
 
 const app = express()
 
-app.engine('hbs', expressHandlebars({ defaultLayout: 'main' }))
+app.engine('hbs', engine({ defaultLayout: 'main' }))
 app.set('view engine', 'hbs')
 app.set('views', path.join(__dirname, 'views'))
-app.set('port', APP_CONFIG.SERVER_PORT)
+app.set('port', config.app.SERVER_PORT)
 
 app.use(express.static(path.join(__dirname, 'public')))
 app.use(bodyParser.urlencoded({ extended: true }))
@@ -34,12 +31,12 @@ app.use((req, res, next) => {
 // bind routes
 app.get('/', routes.index)
 app.post('/authorize', routes.authorize)
-app.get(`/${USER_CONFIG.CALLBACK_PATH}`, routes.addParticipant)
+app.get(`/${config.user.CALLBACK_PATH}`, routes.addParticipant)
 app.get('/quit', routes.stopServer)
 
 function start() {
 
-  app.listen(APP_CONFIG.SERVER_PORT, () => {
+  app.listen(config.app.SERVER_PORT, () => {
 
     const localUrl = `http://localhost:${app.get('port')}`
     logger.info(`Fbtrack Registration Server running at ${ localUrl }...`)

--- a/src/web/routes.js
+++ b/src/web/routes.js
@@ -1,18 +1,14 @@
 const qs = require('querystring')
-const {
-  FITBIT_CONFIG,
-  APP_CONFIG,
-  USER_CONFIG,
-} = require('../config').getConfig({ requiresUserSetup: true })
+const config = require('../config').getConfig({ requiresUserSetup: true })
 
 const FitBitApiClient = require('fitbit-node')
 const { format } = require('date-fns')
 const Database = require('../models/Database')
 
-const db = new Database({ databaseName: APP_CONFIG.DB_NAME })
+const db = new Database({ databaseName: config.app.DB_NAME })
 const client = new FitBitApiClient({
-  clientId: FITBIT_CONFIG.CLIENT_ID,
-  clientSecret: FITBIT_CONFIG.CLIENT_SECRET
+  clientId: config.fitbit.CLIENT_ID,
+  clientSecret: config.fitbit.CLIENT_SECRET
 })
 const { defaultLogger: logger } = require('../lib/logger')
 
@@ -25,7 +21,7 @@ const {
 const index = (req, res) => {
   res.render('signup', {
     layout: 'main.hbs',
-    studyName: USER_CONFIG.STUDY_NAME
+    studyName: config.user.STUDY_NAME
   })
 };
 
@@ -68,7 +64,7 @@ const authorize = async (req, res) => {
 
     const state = qs.encode({ participantId, participantStartDate })
     const prompt = 'login consent'
-    const redirectURI = client.getAuthorizeUrl(FITBIT_CONFIG.SCOPE, FITBIT_CONFIG.CALLBACK_URL, prompt, state)
+    const redirectURI = client.getAuthorizeUrl(config.fitbit.SCOPE, config.fitbit.CALLBACK_URL, prompt, state)
 
     await res.json({ data: { redirectURI } })
 
@@ -100,7 +96,7 @@ async function addParticipant(req, res) {
     tokens = {
       access_token,
       refresh_token
-    } = await client.getAccessToken(code, FITBIT_CONFIG.CALLBACK_URL)
+    } = await client.getAccessToken(code, config.fitbit.CALLBACK_URL)
 
   } catch(e) {
 

--- a/todo.txt
+++ b/todo.txt
@@ -7,9 +7,9 @@ features:
         - move data/combine.js code to src/lib/io.js
     - update 'report' sub-command with new subject/participant models
     - 'report' sub-command to show:
-        - subjects' registration date, date range collected (+ any missing dates)
+        - subjects' registration date, date range collected (+ any missing dates) 
     - allow any valid date string to 'fbtrack query -d <start>...<stop>', not just '/' separator
-    - let user pass subject id via cli to web (optional), by running 'fbt signup <subjectId>`.
+    - let user pass subject id via cli to web (optional), by running 'fbt signup <subjectId>`. 
     - React app for data visualization
         - try basic plugin-architecture for end-user analysis
     - allow multiple studies
@@ -33,7 +33,6 @@ bugs:
     - prevent refresh token errors. got a 400 invalid refresh token, with an old refresh token in db.
 
 refactor:
-    - date boundary code very unclear.
     - validation logic in src/cli/validators.js is a bit hard to read.
     - rename database from <study_name>.sqlite to <study_name>.db.
     - restructure lib directory, organization of files doesn't make that much sense.


### PR DESCRIPTION
- Change date query interface to allow one or two space separated dates. if args is [d1], d1 is stop date, start date is stop - windowSize days. if args is [d1,d2], dates are start date, stop date.

- Feplace date-fns `format()` calls with custom YYYY-mm-dd function that assumes local timezone.  My use of format uninentionally included timezone information which caused the dates to be off by 1, e.g. 2020-01-01 became 2019-12-31 because of how that date is translated into UTC timezone.